### PR TITLE
docker-compose file to deploy congatudo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  congatudo:
+    container_name: congatudo
+    image: ghcr.io/congatudo/congatudo:alpine-latest
+    restart: always
+    volumes:
+     - ./congatudo/congatudo_data:/data
+     - ./congatudo/config/congatudo.json:/etc/valetudo/config.json
+    ports:
+      - 80:80
+      - 4010:4010
+      - 4030:4030
+      - 4050:4050
+  broker:
+    container_name: mqtt
+    image: eclipse-mosquitto
+    volumes:
+      - ./mosquitto:/mosquitto
+    ports:
+      - "1883:1883"
+    restart: always


### PR DESCRIPTION
This is an example to deploy congatudo+mqtt broker using congatudo standalone installation with docker-compose.  Keep in mind paths are relative and should be updated to your needs. First time running it will give eacces error to congatudo.json file, if you have any, it will overwrite it with default one, you need to chmod 777 it so you can work with it, Once done, configure it using the robot implementation, server IP for congatudo and mqtt, and user/pass for each.
